### PR TITLE
Fix: NullReferenceException in UserSession Timer & Race Condition Handling

### DIFF
--- a/MoneyMindManager.UI/Forms/Main/frmMain.Designer.cs
+++ b/MoneyMindManager.UI/Forms/Main/frmMain.Designer.cs
@@ -593,7 +593,6 @@
             this.Text = "Money Mind Manager";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.frmMain_FormClosing);
             this.Load += new System.EventHandler(this.frmMain_Load);
-            this.Shown += new System.EventHandler(this.frmMain_Shown);
             this.gpnlRightBar.ResumeLayout(false);
             this.gpnlRightBar.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.guna2PictureBox1)).EndInit();

--- a/MoneyMindManager.UI/Forms/Main/frmMain.cs
+++ b/MoneyMindManager.UI/Forms/Main/frmMain.cs
@@ -132,9 +132,7 @@ namespace MoneyMindManager_Presentation.Main
                 this.Close();
                 return;
             };
-        }
-        private void frmMain_Shown(object sender, EventArgs e)
-        {
+
             LoadMainFormLabels();
 
             prevButton = null;


### PR DESCRIPTION
Fix a race condition where the timer ticked before async session initialization was complete.
 move frmMain_Shown code at frmMain_Load.